### PR TITLE
Trim the data field of dquotes when finding records

### DIFF
--- a/client.go
+++ b/client.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/cookiejar"
+	"strings"
 	"time"
 
 	"github.com/pquerna/otp/totp"
@@ -151,7 +152,7 @@ func (c *client) findRecords(ctx context.Context, record nameserverRecord, domai
 	}
 
 	if matchContent {
-		request.Content = record.Content
+		request.Content = strings.Trim(record.Content, "\"")
 	}
 
 	response, err := c.call(ctx, "nameserver.info", request)


### PR DESCRIPTION
The INWX API trims leading and trailing quotes in the data field, so it's not possible to create e.g. TXT records with quoted content.
Meaning you don't ever want to look for records that have data which is surrounded by quotes.

I don't know if the change covers enough or too much. I have only observed this with TXT records and only with double quotes (single quotes seem to behave normally).

I don't think the failing tests have anything to do with the change since the #27 has the exact same failures.