### PR TITLE
Handle updating records with multiple values

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -92,42 +92,59 @@ func (p *Provider) SetRecords(ctx context.Context, zone string, records []libdns
 		return nil, err
 	}
 
-	var results []libdns.Record
-
+	groupedRecords := map[string](map[string][]libdns.Record){}
 	for _, record := range records {
-		matches, err := p.client.findRecords(ctx, inwxRecord(record), getDomain(zone), false)
-
-		if err != nil {
-			return nil, err
+		rr := record.RR()
+		if _, ok := groupedRecords[rr.Type]; !ok {
+			groupedRecords[rr.Type] = map[string][]libdns.Record{}
 		}
+		groupedRecords[rr.Type][rr.Name] = append(groupedRecords[rr.Type][rr.Name], record)
+	}
 
-		if len(matches) == 0 {
-			_, err := client.createRecord(ctx, inwxRecord(record), getDomain(zone))
-
+	var results []libdns.Record
+	for recordType, typeGroup := range groupedRecords {
+		for recordName, nameGroup := range typeGroup {
+			matches, err := p.client.findRecords(ctx, nameserverRecord{Type: recordType, Name: recordName}, getDomain(zone), false)
 			if err != nil {
 				return nil, err
 			}
+			for i, record := range nameGroup {
 
-			results = append(results, record)
+				if i > len(matches)-1 {
 
-			continue
+					_, err := client.createRecord(ctx, inwxRecord(record), getDomain(zone))
+
+					if err != nil {
+						return nil, err
+					}
+
+				} else {
+
+					inwxRecord := inwxRecord(record)
+					inwxRecord.ID = matches[i].ID
+
+					err = client.updateRecord(ctx, inwxRecord)
+
+					if err != nil {
+						return nil, err
+					}
+
+				}
+
+				results = append(results, record)
+			}
+
+			if len(matches) > len(nameGroup) {
+				for _, record := range matches[len(nameGroup):] {
+					err := client.deleteRecord(ctx, record)
+
+					if err != nil {
+						return nil, err
+					}
+				}
+
+			}
 		}
-
-		if len(matches) > 1 {
-			return nil, fmt.Errorf("unexpectedly found more than 1 record for %v", record)
-		}
-
-		inwxRecord := inwxRecord(record)
-		inwxRecord.ID = matches[0].ID
-
-		err = client.updateRecord(ctx, inwxRecord)
-
-		if err != nil {
-			return nil, err
-		}
-
-		results = append(results, record)
-
 	}
 
 	return results, nil


### PR DESCRIPTION
Previously when creating e.g. A records with multiple IPs one would receive the error message "unexpectedly found more than 1 record for ...".

This change implements code for handling that scenario by grouping records by type and name, and then making the total set of records match the given ones (i.e. update until existing or new list exhausted, then append the remaining new records or delete the remaining existing ones).

EDIT: Highly recommend looking at the diff in split-view. It's a mess to read otherwise.