### PR TITLE
Fix MX & SRV records

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -2,6 +2,7 @@ package inwx
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -44,18 +45,20 @@ func (p *Provider) GetRecords(ctx context.Context, zone string) ([]libdns.Record
 	}
 
 	results := make([]libdns.Record, 0, len(inwxRecords))
+	var errs []error
 
 	for _, inwxRecord := range inwxRecords {
 		result, err := libdnsRecord(inwxRecord, zone)
 
 		if err != nil {
-			return nil, fmt.Errorf("parsing INWX DNS record %+v: %v", inwxRecord, err)
+			errs = append(errs, fmt.Errorf("parsing INWX DNS record %+v: %v", inwxRecord, err))
+			continue
 		}
 
 		results = append(results, result)
 	}
 
-	return results, nil
+	return results, errors.Join(errs...)
 }
 
 // AppendRecords adds records to the zone. It returns the records that were added.
@@ -68,18 +71,20 @@ func (p *Provider) AppendRecords(ctx context.Context, zone string, records []lib
 	}
 
 	var results []libdns.Record
+	var errs []error
 
 	for _, record := range records {
 		var _, err = client.createRecord(ctx, inwxRecord(record), getDomain(zone))
 
 		if err != nil {
-			return nil, err
+			errs = append(errs, err)
+			continue
 		}
 
 		results = append(results, record)
 	}
 
-	return results, nil
+	return results, errors.Join(errs...)
 }
 
 // SetRecords sets the records in the zone, either by updating existing records or creating new ones.
@@ -102,11 +107,14 @@ func (p *Provider) SetRecords(ctx context.Context, zone string, records []libdns
 	}
 
 	var results []libdns.Record
+	var errs []error
+
 	for recordType, typeGroup := range groupedRecords {
 		for recordName, nameGroup := range typeGroup {
 			matches, err := p.client.findRecords(ctx, nameserverRecord{Type: recordType, Name: recordName}, getDomain(zone), false)
 			if err != nil {
-				return nil, err
+				errs = append(errs, err)
+				continue
 			}
 			for i, record := range nameGroup {
 
@@ -115,7 +123,8 @@ func (p *Provider) SetRecords(ctx context.Context, zone string, records []libdns
 					_, err := client.createRecord(ctx, inwxRecord(record), getDomain(zone))
 
 					if err != nil {
-						return nil, err
+						errs = append(errs, err)
+						continue
 					}
 
 				} else {
@@ -126,7 +135,8 @@ func (p *Provider) SetRecords(ctx context.Context, zone string, records []libdns
 					err = client.updateRecord(ctx, inwxRecord)
 
 					if err != nil {
-						return nil, err
+						errs = append(errs, err)
+						continue
 					}
 
 				}
@@ -139,7 +149,8 @@ func (p *Provider) SetRecords(ctx context.Context, zone string, records []libdns
 					err := client.deleteRecord(ctx, record)
 
 					if err != nil {
-						return nil, err
+						errs = append(errs, err)
+						continue
 					}
 				}
 
@@ -147,7 +158,7 @@ func (p *Provider) SetRecords(ctx context.Context, zone string, records []libdns
 		}
 	}
 
-	return results, nil
+	return results, errors.Join(errs...)
 }
 
 // DeleteRecords deletes the records from the zone. It returns the records that were deleted.
@@ -160,26 +171,29 @@ func (p *Provider) DeleteRecords(ctx context.Context, zone string, records []lib
 	}
 
 	var results []libdns.Record
+	var errs []error
 
 	for _, record := range records {
 		exactMatches, err := p.client.findRecords(ctx, inwxRecord(record), getDomain(zone), true)
 
 		if err != nil {
-			return nil, err
+			results = append(results, record)
+			continue
 		}
 
 		for _, inwxRecord := range exactMatches {
 			err := client.deleteRecord(ctx, inwxRecord)
 
 			if err != nil {
-				return nil, err
+				errs = append(errs, err)
+				continue
 			}
 
 			results = append(results, record)
 		}
 	}
 
-	return results, nil
+	return results, errors.Join(errs...)
 }
 
 func (p *Provider) getClient(ctx context.Context) (*client, error) {

--- a/provider.go
+++ b/provider.go
@@ -74,7 +74,14 @@ func (p *Provider) AppendRecords(ctx context.Context, zone string, records []lib
 	var errs []error
 
 	for _, record := range records {
-		var _, err = client.createRecord(ctx, inwxRecord(record), getDomain(zone))
+		inwxRecord, err := inwxRecord(record)
+
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		_, err = client.createRecord(ctx, *inwxRecord, getDomain(zone))
 
 		if err != nil {
 			errs = append(errs, err)
@@ -118,9 +125,16 @@ func (p *Provider) SetRecords(ctx context.Context, zone string, records []libdns
 			}
 			for i, record := range nameGroup {
 
+				inwxRecord, err := inwxRecord(record)
+
+				if err != nil {
+					errs = append(errs, err)
+					continue
+				}
+
 				if i > len(matches)-1 {
 
-					_, err := client.createRecord(ctx, inwxRecord(record), getDomain(zone))
+					_, err := client.createRecord(ctx, *inwxRecord, getDomain(zone))
 
 					if err != nil {
 						errs = append(errs, err)
@@ -129,10 +143,9 @@ func (p *Provider) SetRecords(ctx context.Context, zone string, records []libdns
 
 				} else {
 
-					inwxRecord := inwxRecord(record)
 					inwxRecord.ID = matches[i].ID
 
-					err = client.updateRecord(ctx, inwxRecord)
+					err = client.updateRecord(ctx, *inwxRecord)
 
 					if err != nil {
 						errs = append(errs, err)
@@ -174,7 +187,14 @@ func (p *Provider) DeleteRecords(ctx context.Context, zone string, records []lib
 	var errs []error
 
 	for _, record := range records {
-		exactMatches, err := p.client.findRecords(ctx, inwxRecord(record), getDomain(zone), true)
+		inwxRecord, err := inwxRecord(record)
+
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		exactMatches, err := p.client.findRecords(ctx, *inwxRecord, getDomain(zone), true)
 
 		if err != nil {
 			results = append(results, record)
@@ -260,7 +280,7 @@ func libdnsRecord(record nameserverRecord, zone string) (libdns.Record, error) {
 	}.Parse()
 }
 
-func inwxRecord(record libdns.Record) nameserverRecord {
+func inwxRecord(record libdns.Record) (*nameserverRecord, error) {
 	rr := record.RR()
 
 	inwxRecord := nameserverRecord{
@@ -270,7 +290,12 @@ func inwxRecord(record libdns.Record) nameserverRecord {
 		TTL:     int(rr.TTL.Seconds()),
 	}
 
-	switch rec := record.(type) {
+	parsed, err := rr.Parse()
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse record %s %s: %w", rr.Name, rr.Type, err)
+	}
+
+	switch rec := parsed.(type) {
 	case libdns.MX:
 		inwxRecord.Content = rec.Target
 		inwxRecord.Priority = uint(rec.Preference)
@@ -279,7 +304,7 @@ func inwxRecord(record libdns.Record) nameserverRecord {
 		inwxRecord.Priority = uint(rec.Priority)
 	}
 
-	return inwxRecord
+	return &inwxRecord, nil
 }
 
 // Interface guards

--- a/provider.go
+++ b/provider.go
@@ -92,42 +92,59 @@ func (p *Provider) SetRecords(ctx context.Context, zone string, records []libdns
 		return nil, err
 	}
 
-	var results []libdns.Record
-
+	groupedRecords := map[string](map[string][]libdns.Record){}
 	for _, record := range records {
-		matches, err := p.client.findRecords(ctx, inwxRecord(record), getDomain(zone), false)
-
-		if err != nil {
-			return nil, err
+		rr := record.RR()
+		if _, ok := groupedRecords[rr.Type]; !ok {
+			groupedRecords[rr.Type] = map[string][]libdns.Record{}
 		}
+		groupedRecords[rr.Type][rr.Name] = append(groupedRecords[rr.Type][rr.Name], record)
+	}
 
-		if len(matches) == 0 {
-			_, err := client.createRecord(ctx, inwxRecord(record), getDomain(zone))
-
+	var results []libdns.Record
+	for recordType, typeGroup := range groupedRecords {
+		for recordName, nameGroup := range typeGroup {
+			matches, err := p.client.findRecords(ctx, nameserverRecord{Type: recordType, Name: recordName}, getDomain(zone), false)
 			if err != nil {
 				return nil, err
 			}
+			for i, record := range nameGroup {
 
-			results = append(results, record)
+				if i > len(matches)-1 {
 
-			continue
+					_, err := client.createRecord(ctx, inwxRecord(record), getDomain(zone))
+
+					if err != nil {
+						return nil, err
+					}
+
+				} else {
+
+					inwxRecord := inwxRecord(record)
+					inwxRecord.ID = matches[i].ID
+
+					err = client.updateRecord(ctx, inwxRecord)
+
+					if err != nil {
+						return nil, err
+					}
+
+				}
+
+				results = append(results, record)
+			}
+
+			if len(matches) > len(nameGroup) {
+				for _, record := range matches[len(nameGroup):] {
+					err := client.deleteRecord(ctx, record)
+
+					if err != nil {
+						return nil, err
+					}
+				}
+
+			}
 		}
-
-		if len(matches) > 1 {
-			return nil, fmt.Errorf("unexpectedly found more than 1 record for %v", record)
-		}
-
-		inwxRecord := inwxRecord(record)
-		inwxRecord.ID = matches[0].ID
-
-		err = client.updateRecord(ctx, inwxRecord)
-
-		if err != nil {
-			return nil, err
-		}
-
-		results = append(results, record)
-
 	}
 
 	return results, nil


### PR DESCRIPTION
Based on #30.

I honestly am not quite sure how this worked before. This function: https://github.com/libdns/inwx/blob/ab63b13631a13a592aafaf3e04b327b38c7ac0bc/provider.go#L232-L252

... expects `rr.Data` to be set, which is only the case for raw `RR` structs. But then, when checking whether it's an `MX` or `SRV` exactly the opposite is assumed.  
So I'm pretty sure that anyone using this either *never* or *exclusively* uses MX and SRV records.

Here's the libdns RR struct https://github.com/libdns/libdns/blob/d3609c6996e67a8186b81cb4c797dd8c48d5017c/record.go#L111-L114

And here's the MX struct https://github.com/libdns/libdns/blob/d3609c6996e67a8186b81cb4c797dd8c48d5017c/rrtypes.go#L114-L132